### PR TITLE
add(audit): создан аудит для записи действий пользователя

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -49,6 +49,9 @@ jobs:
           echo "GOAL_PORT=${{ secrets.GOAL_PORT }}" >> .env
           echo "DASHBOARD_PORT=${{ secrets.DASHBOARD_PORT }}" >> .env
           
+          echo "AUDIT_PORT=${{ secrets.AUDIT_PORT }}" >> .env
+          echo "AUDIT_SERVICE_URL=http://audit-service:${{ secrets.AUDIT_PORT }}" >> .env
+          
           echo "NOTIFICATION_PORT=8086" >> .env
           echo "KAFKA_BOOTSTRAP_SERVERS=kafka:29092" >> .env
           
@@ -86,6 +89,7 @@ jobs:
             --env-var "transactionBaseUrl=http://localhost:8080/api/v1" \
             --env-var "goalBaseUrl=http://localhost:8080/api/v1" \
             --env-var "dashboardBaseUrl=http://localhost:8080/api/v1" \
+            --env-var "auditBaseUrl=http://localhost:8080/api/v1" \
             --reporters cli
 
       - name: Dump Logs on Failure
@@ -94,6 +98,7 @@ jobs:
           docker compose logs gateway-service
           docker compose logs auth-service
           docker compose logs budget-service
+          docker compose logs audit-service
 
       - name: Stop Services
         if: always()

--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -90,6 +90,7 @@ jobs:
             --env-var "goalBaseUrl=http://localhost:8080/api/v1" \
             --env-var "dashboardBaseUrl=http://localhost:8080/api/v1" \
             --env-var "auditBaseUrl=http://localhost:8080/api/v1" \
+            --delay-request 3000 \
             --reporters cli
 
       - name: Dump Logs on Failure

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -90,6 +90,13 @@ jobs:
           push: true
           tags: ${{ secrets.DOCKER_USERNAME }}/smart-budget-notification:latest
 
+      - name: Build & Push Audit Service
+        uses: docker/build-push-action@v5
+        with:
+          context: ./audit-service
+          push: true
+          tags: ${{ secrets.DOCKER_USERNAME }}/smart-budget-audit:latest
+
 #  deploy-to-yandex:
 #    needs: build-and-push
 #    runs-on: ubuntu-latest
@@ -134,6 +141,9 @@ jobs:
 #            echo "GOAL_PORT=${{ secrets.GOAL_PORT }}" >> .env
 #            echo "DASHBOARD_PORT=${{ secrets.DASHBOARD_PORT }}" >> .env
 #
+#            echo "AUDIT_PORT=${{ secrets.AUDIT_PORT }}" >> .env
+#            echo "AUDIT_SERVICE_URL=${{ secrets.AUDIT_SERVICE_URL }}" >> .env
+#
 #            echo "NOTIFICATION_PORT=8086" >> .env
 #            echo "KAFKA_BOOTSTRAP_SERVERS=kafka:29092" >> .env
 #
@@ -144,6 +154,7 @@ jobs:
 #            echo "BANK_SERVICE_URL=http://bank-service:${{ secrets.BANK_PORT }}" >> .env
 #            echo "DASHBOARD_SERVICE_URL=http://dashboard-service:${{ secrets.DASHBOARD_PORT }}" >> .env
 #            echo "NOTIFICATION_SERVICE_URL=http://notification-service:8086" >> .env
+#            echo "AUDIT_SERVICE_URL=${{ secrets.AUDIT_SERVICE_URL }}" >> .env
 #
 #            echo "S3_URL=${{ secrets.S3_URL }}" >> .env
 #            echo "S3_ACCESS_KEY=${{ secrets.S3_ACCESS_KEY }}" >> .env

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/audit-service/src/main/java" charset="UTF-8" />
+    <file url="file://$PROJECT_DIR$/audit-service/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/auth-service/src/main/java" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/auth-service/src/main/resources" charset="UTF-8" />
     <file url="file://$PROJECT_DIR$/bank-service/src/main/java" charset="UTF-8" />

--- a/audit-service/Dockerfile
+++ b/audit-service/Dockerfile
@@ -1,0 +1,15 @@
+FROM eclipse-temurin:21-jdk-jammy AS builder
+
+WORKDIR /app
+COPY target/audit-service-1.0-SNAPSHOT.jar app.jar
+RUN java -Djarmode=layertools -jar app.jar extract
+FROM eclipse-temurin:21-jre-jammy
+WORKDIR /app
+
+COPY --from=builder /app/dependencies/ ./
+COPY --from=builder /app/spring-boot-loader/ ./
+COPY --from=builder /app/snapshot-dependencies/ ./
+COPY --from=builder /app/application/ ./
+
+ENTRYPOINT ["java", "org.springframework.boot.loader.launch.JarLauncher"]
+EXPOSE 8090

--- a/audit-service/pom.xml
+++ b/audit-service/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>t-bank</groupId>
+        <artifactId>smart-budget</artifactId>
+        <version>1.0-SNAPSHOT</version>
+    </parent>
+    <artifactId>audit-service</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-jpa</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.postgresql</groupId>
+            <artifactId>postgresql</artifactId>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.liquibase</groupId>
+            <artifactId>liquibase-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>t-bank</groupId>
+            <artifactId>core</artifactId>
+            <version>1.0-SNAPSHOT</version>
+            <scope>compile</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>s3</artifactId>
+            <version>2.25.11</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+                <version>${spring.boot.version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
+                <configuration>
+                    <layers>
+                        <enabled>true</enabled>
+                    </layers>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/audit-service/src/main/java/com/teamfourpixels/AuditServiceApplication.java
+++ b/audit-service/src/main/java/com/teamfourpixels/AuditServiceApplication.java
@@ -1,0 +1,11 @@
+package com.teamfourpixels;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AuditServiceApplication {
+    public static void main(String[] args) {
+        SpringApplication.run(AuditServiceApplication.class, args);
+    }
+}

--- a/audit-service/src/main/java/com/teamfourpixels/config/SecurityConfig.java
+++ b/audit-service/src/main/java/com/teamfourpixels/config/SecurityConfig.java
@@ -1,0 +1,35 @@
+package com.teamfourpixels.config;
+
+import com.teamfourpixels.security.JwtAuthenticationFilter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/actuator/**", "/swagger-ui/**", "/v3/api-docs/**", "/error").permitAll()
+                        .requestMatchers("/api/**").authenticated()
+                        .anyRequest().denyAll()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/audit-service/src/main/java/com/teamfourpixels/controller/AuditController.java
+++ b/audit-service/src/main/java/com/teamfourpixels/controller/AuditController.java
@@ -1,0 +1,31 @@
+package com.teamfourpixels.controller;
+
+import com.teamfourpixels.entity.AuditLog;
+import com.teamfourpixels.repository.AuditLogRepository;
+import com.teamfourpixels.util.UserContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/audit")
+@RequiredArgsConstructor
+public class AuditController {
+
+    private final AuditLogRepository auditLogRepository;
+
+    @GetMapping("/transactions/{transactionId}")
+    public ResponseEntity<List<AuditLog>> getTransactionHistory(@PathVariable Long transactionId) {
+        List<AuditLog> history = auditLogRepository.findByTransactionIdOrderByTimestampDesc(transactionId);
+        return ResponseEntity.ok(history);
+    }
+
+    @GetMapping("/user")
+    public ResponseEntity<List<AuditLog>> getUserHistory() {
+        Long userId = UserContext.getUserId();
+        List<AuditLog> history = auditLogRepository.findByUserIdOrderByTimestampDesc(userId);
+        return ResponseEntity.ok(history);
+    }
+}

--- a/audit-service/src/main/java/com/teamfourpixels/entity/AuditLog.java
+++ b/audit-service/src/main/java/com/teamfourpixels/entity/AuditLog.java
@@ -1,0 +1,27 @@
+package com.teamfourpixels.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "audit_logs")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AuditLog {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String eventId;
+    private String action;
+    private Long userId;
+    private Long transactionId;
+    private Long oldCategoryId;
+    private Long newCategoryId;
+    private LocalDateTime timestamp;
+    private LocalDateTime processedAt;
+}

--- a/audit-service/src/main/java/com/teamfourpixels/mapper/AuditMapper.java
+++ b/audit-service/src/main/java/com/teamfourpixels/mapper/AuditMapper.java
@@ -1,0 +1,37 @@
+package com.teamfourpixels.mapper;
+
+import com.teamfourpixels.dto.AuditEventDto;
+import com.teamfourpixels.dto.BudgetLimitEvent;
+import com.teamfourpixels.entity.AuditLog;
+import org.springframework.stereotype.Component;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+@Component
+public class AuditMapper {
+
+    public AuditLog toEntity(AuditEventDto dto) {
+        return AuditLog.builder()
+                .eventId(dto.getEventId())
+                .action(dto.getAction())
+                .userId(dto.getUserId())
+                .transactionId(dto.getTransactionId())
+                .oldCategoryId(dto.getOldCategoryId())
+                .newCategoryId(dto.getNewCategoryId())
+                .timestamp(dto.getTimestamp())
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+
+    public AuditLog toEntity(BudgetLimitEvent event) {
+        return AuditLog.builder()
+                .eventId(UUID.randomUUID().toString())
+                .action("LIMIT_REACHED_" + event.getPercentage())
+                .userId(event.getUserId())
+                .newCategoryId(event.getCategoryId())
+                .timestamp(LocalDateTime.now())
+                .processedAt(LocalDateTime.now())
+                .build();
+    }
+}

--- a/audit-service/src/main/java/com/teamfourpixels/repository/AuditLogRepository.java
+++ b/audit-service/src/main/java/com/teamfourpixels/repository/AuditLogRepository.java
@@ -1,0 +1,14 @@
+package com.teamfourpixels.repository;
+
+import com.teamfourpixels.entity.AuditLog;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface AuditLogRepository extends JpaRepository<AuditLog, Long> {
+    List<AuditLog> findByTransactionIdOrderByTimestampDesc(Long transactionId);
+
+    List<AuditLog> findByUserIdOrderByTimestampDesc(Long userId);
+}

--- a/audit-service/src/main/java/com/teamfourpixels/service/AuditEventListener.java
+++ b/audit-service/src/main/java/com/teamfourpixels/service/AuditEventListener.java
@@ -1,76 +1,30 @@
 package com.teamfourpixels.service;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.teamfourpixels.dto.AuditEventDto;
 import com.teamfourpixels.dto.BudgetLimitEvent;
-import com.teamfourpixels.entity.AuditLog;
-import com.teamfourpixels.repository.AuditLogRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.kafka.annotation.KafkaListener;
-import org.springframework.stereotype.Service;
-
-import java.time.LocalDateTime;
+import org.springframework.stereotype.Component;
 
 @Slf4j
-@Service
+@Component
 @RequiredArgsConstructor
 public class AuditEventListener {
 
-    private final AuditLogRepository auditLogRepository;
-    private final ObjectMapper objectMapper;
+    private final AuditService auditService;
 
     @KafkaListener(topics = "audit-events", groupId = "audit-group")
-    public void consumeAuditEvent(String payload) {
-        try {
-            objectMapper.registerModule(new JavaTimeModule());
-
-            AuditEventDto eventDto = objectMapper.readValue(payload, AuditEventDto.class);
-            log.info("Получено событие аудита: {} для транзакции {}", eventDto.getAction(), eventDto.getTransactionId());
-
-            AuditLog auditLog = AuditLog.builder()
-                    .eventId(eventDto.getEventId())
-                    .action(eventDto.getAction())
-                    .userId(eventDto.getUserId())
-                    .transactionId(eventDto.getTransactionId())
-                    .oldCategoryId(eventDto.getOldCategoryId())
-                    .newCategoryId(eventDto.getNewCategoryId())
-                    .timestamp(eventDto.getTimestamp())
-                    .processedAt(LocalDateTime.now())
-                    .build();
-
-            auditLogRepository.save(auditLog);
-            log.info("Событие успешно сохранено в БД аудита.");
-
-        } catch (Exception e) {
-            log.error("Ошибка при обработке события аудита: {}", e.getMessage());
-        }
+    public void consumeAuditEvent(AuditEventDto eventDto) {
+        log.info("Получено событие аудита: {} для транзакции {}",
+                eventDto.getAction(), eventDto.getTransactionId());
+        auditService.saveAuditEvent(eventDto);
     }
 
     @KafkaListener(topics = "budget-limit-events", groupId = "audit-group")
-    public void consumeBudgetLimitEvent(String payload) {
-        try {
-            objectMapper.registerModule(new JavaTimeModule());
-
-            BudgetLimitEvent eventDto = objectMapper.readValue(payload, BudgetLimitEvent.class);
-            log.info("Аудит поймал событие достижения лимита: user={}, category={}, израсходовано={}%",
-                    eventDto.getUserId(), eventDto.getCategoryId(), eventDto.getPercentage());
-
-            AuditLog auditLog = AuditLog.builder()
-                    .eventId(java.util.UUID.randomUUID().toString())
-                    .action("LIMIT_REACHED_" + eventDto.getPercentage())
-                    .userId(eventDto.getUserId())
-                    .newCategoryId(eventDto.getCategoryId())
-                    .timestamp(LocalDateTime.now())
-                    .processedAt(LocalDateTime.now())
-                    .build();
-
-            auditLogRepository.save(auditLog);
-            log.info("Событие лимита успешно сохранено в БД аудита.");
-
-        } catch (Exception e) {
-            log.error("Ошибка при обработке события лимита в аудите: {}", e.getMessage());
-        }
+    public void consumeBudgetLimitEvent(BudgetLimitEvent eventDto) {
+        log.info("Аудит поймал событие достижения лимита: user={}, израсходовано={}%",
+                eventDto.getUserId(), eventDto.getPercentage());
+        auditService.saveLimitEvent(eventDto);
     }
 }

--- a/audit-service/src/main/java/com/teamfourpixels/service/AuditEventListener.java
+++ b/audit-service/src/main/java/com/teamfourpixels/service/AuditEventListener.java
@@ -1,0 +1,76 @@
+package com.teamfourpixels.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.teamfourpixels.dto.AuditEventDto;
+import com.teamfourpixels.dto.BudgetLimitEvent;
+import com.teamfourpixels.entity.AuditLog;
+import com.teamfourpixels.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Service;
+
+import java.time.LocalDateTime;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuditEventListener {
+
+    private final AuditLogRepository auditLogRepository;
+    private final ObjectMapper objectMapper;
+
+    @KafkaListener(topics = "audit-events", groupId = "audit-group")
+    public void consumeAuditEvent(String payload) {
+        try {
+            objectMapper.registerModule(new JavaTimeModule());
+
+            AuditEventDto eventDto = objectMapper.readValue(payload, AuditEventDto.class);
+            log.info("Получено событие аудита: {} для транзакции {}", eventDto.getAction(), eventDto.getTransactionId());
+
+            AuditLog auditLog = AuditLog.builder()
+                    .eventId(eventDto.getEventId())
+                    .action(eventDto.getAction())
+                    .userId(eventDto.getUserId())
+                    .transactionId(eventDto.getTransactionId())
+                    .oldCategoryId(eventDto.getOldCategoryId())
+                    .newCategoryId(eventDto.getNewCategoryId())
+                    .timestamp(eventDto.getTimestamp())
+                    .processedAt(LocalDateTime.now())
+                    .build();
+
+            auditLogRepository.save(auditLog);
+            log.info("Событие успешно сохранено в БД аудита.");
+
+        } catch (Exception e) {
+            log.error("Ошибка при обработке события аудита: {}", e.getMessage());
+        }
+    }
+
+    @KafkaListener(topics = "budget-limit-events", groupId = "audit-group")
+    public void consumeBudgetLimitEvent(String payload) {
+        try {
+            objectMapper.registerModule(new JavaTimeModule());
+
+            BudgetLimitEvent eventDto = objectMapper.readValue(payload, BudgetLimitEvent.class);
+            log.info("Аудит поймал событие достижения лимита: user={}, category={}, израсходовано={}%",
+                    eventDto.getUserId(), eventDto.getCategoryId(), eventDto.getPercentage());
+
+            AuditLog auditLog = AuditLog.builder()
+                    .eventId(java.util.UUID.randomUUID().toString())
+                    .action("LIMIT_REACHED_" + eventDto.getPercentage())
+                    .userId(eventDto.getUserId())
+                    .newCategoryId(eventDto.getCategoryId())
+                    .timestamp(LocalDateTime.now())
+                    .processedAt(LocalDateTime.now())
+                    .build();
+
+            auditLogRepository.save(auditLog);
+            log.info("Событие лимита успешно сохранено в БД аудита.");
+
+        } catch (Exception e) {
+            log.error("Ошибка при обработке события лимита в аудите: {}", e.getMessage());
+        }
+    }
+}

--- a/audit-service/src/main/java/com/teamfourpixels/service/AuditService.java
+++ b/audit-service/src/main/java/com/teamfourpixels/service/AuditService.java
@@ -1,0 +1,34 @@
+package com.teamfourpixels.service;
+
+import com.teamfourpixels.dto.AuditEventDto;
+import com.teamfourpixels.dto.BudgetLimitEvent;
+import com.teamfourpixels.entity.AuditLog;
+import com.teamfourpixels.mapper.AuditMapper;
+import com.teamfourpixels.repository.AuditLogRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuditService {
+
+    private final AuditLogRepository auditLogRepository;
+    private final AuditMapper auditMapper;
+
+    @Transactional
+    public void saveAuditEvent(AuditEventDto eventDto) {
+        AuditLog auditLog = auditMapper.toEntity(eventDto);
+        auditLogRepository.save(auditLog);
+        log.info("Событие аудита {} успешно сохранено.", eventDto.getEventId());
+    }
+
+    @Transactional
+    public void saveLimitEvent(BudgetLimitEvent eventDto) {
+        AuditLog auditLog = auditMapper.toEntity(eventDto);
+        auditLogRepository.save(auditLog);
+        log.info("Событие лимита для пользователя {} сохранено.", eventDto.getUserId());
+    }
+}

--- a/audit-service/src/main/resources/application.yml
+++ b/audit-service/src/main/resources/application.yml
@@ -17,10 +17,17 @@ spring:
   kafka:
     bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
     consumer:
+      bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS:localhost:9092}
       group-id: audit-group
       auto-offset-reset: earliest
+      # Используем ErrorHandlingDeserializer для надежности
       key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
-      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.springframework.kafka.support.serializer.ErrorHandlingDeserializer
+      properties:
+        # Указываем основной десериализатор для значений
+        spring.deserializer.value.delegate.class: org.springframework.kafka.support.serializer.JsonDeserializer
+        # Разрешаем доверяемые пакеты для десериализации DTO
+        spring.json.trusted.packages: "com.teamfourpixels.dto"
 
 jwt:
   secret: ${JWT_SECRET}

--- a/audit-service/src/main/resources/application.yml
+++ b/audit-service/src/main/resources/application.yml
@@ -1,0 +1,27 @@
+server:
+  port: ${SERVER_PORT}
+
+spring:
+  application:
+    name: audit-service
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+  jpa:
+    hibernate:
+      ddl-auto: none
+    show-sql: true
+  liquibase:
+    change-log: classpath:db/changelog/db.changelog-master.yaml
+  kafka:
+    bootstrap-servers: ${KAFKA_BOOTSTRAP_SERVERS}
+    consumer:
+      group-id: audit-group
+      auto-offset-reset: earliest
+      key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+      value-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+
+jwt:
+  secret: ${JWT_SECRET}
+  expiration: 3600000

--- a/audit-service/src/main/resources/db/changelog/changes/01-create-audit-logs-table.sql
+++ b/audit-service/src/main/resources/db/changelog/changes/01-create-audit-logs-table.sql
@@ -1,0 +1,13 @@
+CREATE TABLE audit_logs (
+    id BIGSERIAL PRIMARY KEY,
+    event_id VARCHAR(36) NOT NULL,
+    action VARCHAR(50) NOT NULL,
+    user_id BIGINT NOT NULL,
+    transaction_id BIGINT,
+    old_category_id BIGINT,
+    new_category_id BIGINT,
+    timestamp TIMESTAMP NOT NULL,
+    processed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_audit_transaction_id ON audit_logs(transaction_id);

--- a/audit-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/audit-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,0 +1,3 @@
+databaseChangeLog:
+  - include:
+      file: db/changelog/changes/01-create-audit-logs-table.sql

--- a/budget-service/src/main/java/com/teamfourpixels/config/KafkaProducerConfig.java
+++ b/budget-service/src/main/java/com/teamfourpixels/config/KafkaProducerConfig.java
@@ -1,6 +1,5 @@
 package com.teamfourpixels.config;
 
-import com.teamfourpixels.dto.BudgetLimitEvent;
 import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
@@ -21,7 +20,7 @@ public class KafkaProducerConfig {
     private String bootstrapServers;
 
     @Bean
-    public ProducerFactory<String, BudgetLimitEvent> producerFactory() {
+    public ProducerFactory<String, Object> producerFactory() {
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
@@ -30,7 +29,7 @@ public class KafkaProducerConfig {
     }
 
     @Bean
-    public KafkaTemplate<String, BudgetLimitEvent> kafkaTemplate() {
+    public KafkaTemplate<String, Object> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
     }
 }

--- a/budget-service/src/main/java/com/teamfourpixels/service/BudgetServiceImpl.java
+++ b/budget-service/src/main/java/com/teamfourpixels/service/BudgetServiceImpl.java
@@ -30,7 +30,7 @@ public class BudgetServiceImpl implements BudgetService {
     private final BudgetMapper budgetMapper;
     private final CategoryRepository categoryRepository;
     private final TransactionRepository transactionRepository;
-    private final KafkaTemplate<String, BudgetLimitEvent> kafkaTemplate;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
 
     @Override
     @Transactional
@@ -50,7 +50,17 @@ public class BudgetServiceImpl implements BudgetService {
         List<BudgetLimit> newLimits = budgetMapper.toLimitEntities(request.getLimits(), budget);
         budget.getLimits().addAll(newLimits);
 
-        return budgetMapper.toDto(budgetRepository.save(budget));
+        Budget savedBudget = budgetRepository.save(budget);
+
+        AuditEventDto budgetEvent = AuditEventDto.builder()
+                .eventId(java.util.UUID.randomUUID().toString())
+                .action("BUDGET_CONFIGURED")
+                .userId(userId)
+                .timestamp(java.time.LocalDateTime.now())
+                .build();
+        kafkaTemplate.send("audit-events", userId.toString(), budgetEvent);
+
+        return budgetMapper.toDto(savedBudget);
     }
 
     @Override
@@ -131,6 +141,14 @@ public class BudgetServiceImpl implements BudgetService {
         budgetRepository.findByUserIdAndYearAndMonth(userId, year, month)
                 .orElseThrow(() -> new EntityNotFoundException("Resource not found"));
         budgetRepository.deleteByUserIdAndYearAndMonth(userId, year, month);
+
+        AuditEventDto deleteEvent = AuditEventDto.builder()
+                .eventId(java.util.UUID.randomUUID().toString())
+                .action("BUDGET_DELETED")
+                .userId(userId)
+                .timestamp(java.time.LocalDateTime.now())
+                .build();
+        kafkaTemplate.send("audit-events", userId.toString(), deleteEvent);
     }
 
     private void validatePercentLimits(CreateBudgetRequest request) {

--- a/core/src/main/java/com/teamfourpixels/dto/AuditEventDto.java
+++ b/core/src/main/java/com/teamfourpixels/dto/AuditEventDto.java
@@ -1,0 +1,22 @@
+package com.teamfourpixels.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class AuditEventDto {
+    private String eventId;
+    private String action;
+    private Long userId;
+    private Long transactionId;
+    private Long oldCategoryId;
+    private Long newCategoryId;
+    private LocalDateTime timestamp;
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
 
   minio:
     image: minio/minio
-    container_name: smartbudget-minio
+    container_name: minio
     ports:
       - "${MINIO_PORT}:${MINIO_PORT}"
       - "${MINIO_CONSOLE_PORT}:${MINIO_CONSOLE_PORT}"
@@ -34,7 +34,7 @@ services:
 
   zookeeper:
     image: confluentinc/cp-zookeeper:7.4.4
-    container_name: smartbudget-zookeeper
+    container_name: zookeeper
     restart: always
     environment:
       ZOOKEEPER_CLIENT_PORT: 2181
@@ -44,7 +44,7 @@ services:
 
   kafka:
     image: confluentinc/cp-kafka:7.4.4
-    container_name: smartbudget-kafka
+    container_name: kafka
     restart: always
     depends_on:
       - zookeeper
@@ -74,6 +74,7 @@ services:
       BANK_SERVICE_URL: ${BANK_SERVICE_URL}
       DASHBOARD_SERVICE_URL: ${DASHBOARD_SERVICE_URL}
       NOTIFICATION_SERVICE_URL: ${NOTIFICATION_SERVICE_URL}
+      AUDIT_SERVICE_URL: ${AUDIT_SERVICE_URL}
       JWT_SECRET: ${JWT_SECRET}
     depends_on:
       auth-service:
@@ -82,6 +83,26 @@ services:
         condition: service_healthy
       transaction-service:
         condition: service_healthy
+
+  audit-service:
+    build:
+      context: ./audit-service
+    container_name: audit-service
+    ports:
+      - "${AUDIT_PORT}:${AUDIT_PORT}"
+    environment:
+      - SERVER_PORT=${AUDIT_PORT}
+      - DB_HOST=${DB_HOST}
+      - DB_PORT=${DB_PORT}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+      - KAFKA_BOOTSTRAP_SERVERS=${KAFKA_BOOTSTRAP_SERVERS}
+      - JWT_SECRET=${JWT_SECRET}
+      - JWT_EXPIRATION=${JWT_EXPIRATION}
+    depends_on:
+      - db
+      - kafka
 
   auth-service:
     build: ./auth-service
@@ -256,7 +277,7 @@ services:
 
   notification-service:
     build: ./notification-service
-    container_name: smartbudget-notification-service
+    container_name: notification-service
     environment:
       SERVER_PORT: ${NOTIFICATION_PORT}
       DB_HOST: db

--- a/gateway-service/src/main/resources/application.yml
+++ b/gateway-service/src/main/resources/application.yml
@@ -55,6 +55,11 @@ spring:
           predicates:
             - Path=/api/v1/notifications/**
 
+        - id: audit-service
+          uri: ${AUDIT_SERVICE_URL}
+          predicates:
+            - Path=/api/v1/audit/**
+
   servlet:
     multipart:
       max-file-size: 5MB

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.copyableAnnotations += org.springframework.beans.factory.annotation.Qualifier

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
         <module>auth-service</module>
         <module>gateway-service</module>
         <module>notification-service</module>
+        <module>audit-service</module>
     </modules>
 
     <properties>

--- a/transaction-service/src/main/java/com/teamfourpixels/TransactionServiceApplication.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/TransactionServiceApplication.java
@@ -3,9 +3,11 @@ package com.teamfourpixels;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAsync
+@EnableScheduling
 public class TransactionServiceApplication {
     public static void main(String[] args) {
         SpringApplication.run(TransactionServiceApplication.class, args);

--- a/transaction-service/src/main/java/com/teamfourpixels/config/KafkaProducerConfig.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/config/KafkaProducerConfig.java
@@ -6,6 +6,7 @@ import org.apache.kafka.common.serialization.StringSerializer;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 import org.springframework.kafka.core.DefaultKafkaProducerFactory;
 import org.springframework.kafka.core.KafkaTemplate;
 import org.springframework.kafka.core.ProducerFactory;
@@ -30,7 +31,22 @@ public class KafkaProducerConfig {
     }
 
     @Bean
+    @Primary
     public KafkaTemplate<String, TransactionCreatedEvent> kafkaTemplate() {
         return new KafkaTemplate<>(producerFactory());
+    }
+
+    @Bean
+    public ProducerFactory<String, String> stringProducerFactory() {
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> stringKafkaTemplate() {
+        return new KafkaTemplate<>(stringProducerFactory());
     }
 }

--- a/transaction-service/src/main/java/com/teamfourpixels/controller/TransactionController.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/controller/TransactionController.java
@@ -29,13 +29,8 @@ public class TransactionController {
             @RequestParam(required = false) Long startDateMillis,
             @RequestParam(required = false) Long endDateMillis) {
 
-        Instant start = startDateMillis != null
-                ? Instant.ofEpochMilli(startDateMillis)
-                : Instant.EPOCH;
-
-        Instant end = endDateMillis != null
-                ? Instant.ofEpochMilli(endDateMillis)
-                : Instant.now();
+        Instant start = startDateMillis != null ? Instant.ofEpochMilli(startDateMillis) : null;
+        Instant end = endDateMillis != null ? Instant.ofEpochMilli(endDateMillis) : null;
 
         return service.getTransactionsPage(UserContext.getUserId(), page, size, categoryId, query, start, end);
     }

--- a/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
@@ -12,6 +12,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Builder
 public class OutboxEvent {
+
     @Id
     private String id;
 

--- a/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
@@ -1,0 +1,32 @@
+package com.teamfourpixels.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "outbox_events")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class OutboxEvent {
+    @Id
+    private String id;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private String aggregateId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
+
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String payload;
+
+    @Column(nullable = false)
+    private String status;
+
+    @Column(name = "created_at", updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
@@ -5,7 +5,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "outbox_events")
+@Table(name = "outbox")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -13,20 +13,17 @@ import java.time.LocalDateTime;
 @Builder
 public class OutboxEvent {
     @Id
-    private String id;
-
-    @Column(name = "aggregate_id", nullable = false)
-    private String aggregateId;
-
-    @Column(name = "event_type", nullable = false)
-    private String eventType;
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String payload;
 
-    @Column(nullable = false)
-    private String status;
-
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        this.createdAt = LocalDateTime.now();
+    }
 }

--- a/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/entity/OutboxEvent.java
@@ -5,7 +5,7 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "outbox")
+@Table(name = "outbox_events")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -13,17 +13,20 @@ import java.time.LocalDateTime;
 @Builder
 public class OutboxEvent {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+    private String id;
+
+    @Column(name = "aggregate_id", nullable = false)
+    private String aggregateId;
+
+    @Column(name = "event_type", nullable = false)
+    private String eventType;
 
     @Column(columnDefinition = "TEXT", nullable = false)
     private String payload;
 
+    @Column(nullable = false)
+    private String status;
+
     @Column(name = "created_at", updatable = false)
     private LocalDateTime createdAt;
-
-    @PrePersist
-    protected void onCreate() {
-        this.createdAt = LocalDateTime.now();
-    }
 }

--- a/transaction-service/src/main/java/com/teamfourpixels/mapper/TransactionMapper.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/mapper/TransactionMapper.java
@@ -11,8 +11,10 @@ import com.teamfourpixels.enums.OperationType;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.math.BigDecimal;
+import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
+import java.util.UUID;
 
 @Mapper(componentModel = "spring")
 public abstract class TransactionMapper {
@@ -91,5 +93,17 @@ public abstract class TransactionMapper {
         } catch (EntityNotFoundException e) {
             return CategoryDto.builder().id(categoryId).name("Категория не найдена").isSystem(true).build();
         }
+    }
+
+    public AuditEventDto toAuditEventDto(Transaction transaction, String action, Long oldCategoryId) {
+        return AuditEventDto.builder()
+                .eventId(UUID.randomUUID().toString())
+                .action(action)
+                .userId(transaction.getUserId())
+                .transactionId(transaction.getId())
+                .oldCategoryId(oldCategoryId)
+                .newCategoryId(transaction.getCategoryId())
+                .timestamp(LocalDateTime.now())
+                .build();
     }
 }

--- a/transaction-service/src/main/java/com/teamfourpixels/repository/OutboxEventRepository.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/repository/OutboxEventRepository.java
@@ -1,0 +1,12 @@
+package com.teamfourpixels.repository;
+
+import com.teamfourpixels.entity.OutboxEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface OutboxEventRepository extends JpaRepository<OutboxEvent, String> {
+    List<OutboxEvent> findByStatusOrderByCreatedAtAsc(String status);
+}

--- a/transaction-service/src/main/java/com/teamfourpixels/service/OutboxScheduler.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/OutboxScheduler.java
@@ -1,0 +1,45 @@
+package com.teamfourpixels.service;
+
+import com.teamfourpixels.entity.OutboxEvent;
+import com.teamfourpixels.repository.OutboxEventRepository;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+public class OutboxScheduler {
+
+    private final OutboxEventRepository outboxEventRepository;
+    private final KafkaTemplate<String, String> stringKafkaTemplate;
+    private static final String AUDIT_TOPIC = "audit-events";
+
+    public OutboxScheduler(OutboxEventRepository outboxEventRepository,
+                           @Qualifier("stringKafkaTemplate") KafkaTemplate<String, String> stringKafkaTemplate) {
+        this.outboxEventRepository = outboxEventRepository;
+        this.stringKafkaTemplate = stringKafkaTemplate;
+    }
+
+    @Scheduled(fixedDelay = 5000)
+    @Transactional
+    public void processOutboxEvents() {
+        List<OutboxEvent> pendingEvents = outboxEventRepository.findByStatusOrderByCreatedAtAsc("PENDING");
+
+        for (OutboxEvent event : pendingEvents) {
+            try {
+                stringKafkaTemplate.send(AUDIT_TOPIC, event.getAggregateId(), event.getPayload());
+                event.setStatus("PROCESSED");
+                outboxEventRepository.save(event);
+                log.info("Событие {} успешно отправлено в Kafka", event.getId());
+            } catch (Exception e) {
+                log.error("Ошибка при отправке события {} в Kafka: {}", event.getId(), e.getMessage());
+                break;
+            }
+        }
+    }
+}

--- a/transaction-service/src/main/java/com/teamfourpixels/service/OutboxScheduler.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/OutboxScheduler.java
@@ -1,45 +1,17 @@
 package com.teamfourpixels.service;
 
-import com.teamfourpixels.entity.OutboxEvent;
-import com.teamfourpixels.repository.OutboxEventRepository;
-import lombok.extern.slf4j.Slf4j;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.kafka.core.KafkaTemplate;
+import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
-import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.stereotype.Component;
 
-import java.util.List;
-
-@Slf4j
-@Service
+@Component
+@RequiredArgsConstructor
 public class OutboxScheduler {
 
-    private final OutboxEventRepository outboxEventRepository;
-    private final KafkaTemplate<String, String> stringKafkaTemplate;
-    private static final String AUDIT_TOPIC = "audit-events";
-
-    public OutboxScheduler(OutboxEventRepository outboxEventRepository,
-                           @Qualifier("stringKafkaTemplate") KafkaTemplate<String, String> stringKafkaTemplate) {
-        this.outboxEventRepository = outboxEventRepository;
-        this.stringKafkaTemplate = stringKafkaTemplate;
-    }
+    private final OutboxService outboxService;
 
     @Scheduled(fixedDelay = 5000)
-    @Transactional
     public void processOutboxEvents() {
-        List<OutboxEvent> pendingEvents = outboxEventRepository.findByStatusOrderByCreatedAtAsc("PENDING");
-
-        for (OutboxEvent event : pendingEvents) {
-            try {
-                stringKafkaTemplate.send(AUDIT_TOPIC, event.getAggregateId(), event.getPayload());
-                event.setStatus("PROCESSED");
-                outboxEventRepository.save(event);
-                log.info("Событие {} успешно отправлено в Kafka", event.getId());
-            } catch (Exception e) {
-                log.error("Ошибка при отправке события {} в Kafka: {}", event.getId(), e.getMessage());
-                break;
-            }
-        }
+        outboxService.processPendingEvents();
     }
 }

--- a/transaction-service/src/main/java/com/teamfourpixels/service/OutboxService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/OutboxService.java
@@ -1,0 +1,47 @@
+package com.teamfourpixels.service;
+
+import com.teamfourpixels.entity.OutboxEvent;
+import com.teamfourpixels.repository.OutboxEventRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class OutboxService {
+
+    private final OutboxEventRepository outboxEventRepository;
+
+    @Qualifier("stringKafkaTemplate")
+    private final KafkaTemplate<String, String> kafkaTemplate;
+
+    private static final String AUDIT_TOPIC = "audit-events";
+
+    @Transactional
+    public void processPendingEvents() {
+        List<OutboxEvent> events = outboxEventRepository.findAll();
+        if (events.isEmpty()) return;
+
+        for (OutboxEvent event : events) {
+            try {
+                kafkaTemplate.send(AUDIT_TOPIC, event.getPayload())
+                        .whenComplete((result, ex) -> {
+                            if (ex == null) {
+                                outboxEventRepository.delete(event);
+                                log.info("Событие аудита успешно отправлено.");
+                            } else {
+                                log.error("Ошибка Kafka: {}", ex.getMessage());
+                            }
+                        });
+            } catch (Exception e) {
+                log.error("Критический сбой: {}", e.getMessage());
+            }
+        }
+    }
+}

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionFilterSpecification.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionFilterSpecification.java
@@ -24,7 +24,13 @@ public class TransactionFilterSpecification implements Specification<Transaction
 
         predicate = cb.and(predicate, cb.equal(root.get("userId"), userId));
 
-        predicate = cb.and(predicate, cb.between(root.get("transactionTime"), start, end));
+        if (start != null && end != null) {
+            predicate = cb.and(predicate, cb.between(root.get("transactionTime"), start, end));
+        } else if (start != null) {
+            predicate = cb.and(predicate, cb.greaterThanOrEqualTo(root.get("transactionTime"), start));
+        } else if (end != null) {
+            predicate = cb.and(predicate, cb.lessThanOrEqualTo(root.get("transactionTime"), end));
+        }
 
         if (categoryId != null) {
             predicate = cb.and(predicate, cb.equal(root.get("categoryId"), categoryId));
@@ -32,7 +38,6 @@ public class TransactionFilterSpecification implements Specification<Transaction
 
         if (this.query != null && !this.query.isBlank()) {
             String pattern = "%" + this.query.toLowerCase() + "%";
-
             Predicate searchPredicate = cb.or(
                     cb.like(cb.lower(root.get("merchant")), pattern),
                     cb.like(cb.lower(root.get("description")), pattern)

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -87,33 +87,50 @@ public class TransactionService {
     @Async
     @Transactional
     public CompletableFuture<Integer> importAndClassifyTransactions(Long userId, int year, int month) {
-        List<TransactionDto> bankTransactions = bankServiceClient.fetchTransactions(year, month);
-        int newCount = 0;
+        try {
+            log.info("Начинаем импорт транзакций для пользователя {} за {}/{}", userId, month, year);
+            List<TransactionDto> bankTransactions = bankServiceClient.fetchTransactions(year, month);
 
-        List<ClassificationStrategy> sortedStrategies = classificationStrategies.stream()
-                .sorted(Comparator.comparingInt(ClassificationStrategy::getPriority))
-                .toList();
-
-        for (TransactionDto bankDto : bankTransactions) {
-            if (repository.findByUserIdAndBankTransactionRefId(userId, bankDto.getExternalId()).isPresent()) {
-                continue;
-            }
-            Transaction transaction = convertBankDtoToTransaction(userId, bankDto);
-            Long categoryId = autoClassify(transaction, sortedStrategies);
-            transaction.setCategoryId(categoryId);
-
-            Transaction saved = repository.save(transaction);
-
-            if (saved.getType() == OperationType.EXPENSE) {
-                sendTransactionEvent(saved);
+            if (bankTransactions == null || bankTransactions.isEmpty()) {
+                log.warn("Банк-сервис вернул пустой список транзакций!");
+                return CompletableFuture.completedFuture(0);
             }
 
-            saveAuditToOutbox(saved, "TRANSACTION_IMPORTED", null);
+            int newCount = 0;
+            List<ClassificationStrategy> sortedStrategies = classificationStrategies.stream()
+                    .sorted(Comparator.comparingInt(ClassificationStrategy::getPriority))
+                    .toList();
 
-            newCount++;
+            for (TransactionDto bankDto : bankTransactions) {
+                if (repository.findByUserIdAndBankTransactionRefId(userId, bankDto.getExternalId()).isPresent()) {
+                    continue;
+                }
+
+                Transaction transaction = convertBankDtoToTransaction(userId, bankDto);
+                Long categoryId = autoClassify(transaction, sortedStrategies);
+                transaction.setCategoryId(categoryId);
+
+                Transaction saved = repository.save(transaction);
+
+                if (saved.getType() == OperationType.EXPENSE) {
+                    try {
+                        sendTransactionEvent(saved);
+                    } catch (Exception e) {
+                        log.error("Ошибка отправки в Kafka для транзакции {}: {}", saved.getId(), e.getMessage());
+                    }
+                }
+
+                saveAuditToOutbox(saved, "TRANSACTION_IMPORTED", null);
+                newCount++;
+            }
+
+            log.info("Успешно импортировано {} новых транзакций", newCount);
+            return CompletableFuture.completedFuture(newCount);
+
+        } catch (Exception e) {
+            log.error("КРИТИЧЕСКАЯ ОШИБКА при импорте транзакций для пользователя {}: {}", userId, e.getMessage(), e);
+            return CompletableFuture.failedFuture(e);
         }
-
-        return CompletableFuture.completedFuture(newCount);
     }
 
     @Transactional

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -56,15 +56,10 @@ public class TransactionService {
             AuditEventDto eventDto = mapper.toAuditEventDto(transaction, action, oldCategoryId);
 
             OutboxEvent outboxEvent = OutboxEvent.builder()
-                    .aggregateId(transaction.getId().toString())
-                    .eventType(action)
                     .payload(objectMapper.writeValueAsString(eventDto))
-                    .status("PENDING")
-                    .createdAt(LocalDateTime.now())
                     .build();
 
             outboxEventRepository.save(outboxEvent);
-            log.info("Событие {} успешно сохранено в Outbox для транзакции {}", action, transaction.getId());
         } catch (Exception e) {
             log.error("Ошибка при подготовке события Outbox ({}): {}", action, e.getMessage());
         }

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -29,7 +29,6 @@ import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
-import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -51,6 +50,26 @@ public class TransactionService {
     private static final Long UNCATEGORIZED_ID = 999L;
     private static final Long SPLIT_CATEGORY_ID = -1L;
 
+
+    private void saveAuditToOutbox(Transaction transaction, String action, Long oldCategoryId) {
+        try {
+            AuditEventDto eventDto = mapper.toAuditEventDto(transaction, action, oldCategoryId);
+
+            OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .aggregateId(transaction.getId().toString())
+                    .eventType(action)
+                    .payload(objectMapper.writeValueAsString(eventDto))
+                    .status("PENDING")
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            outboxEventRepository.save(outboxEvent);
+            log.info("Событие {} успешно сохранено в Outbox для транзакции {}", action, transaction.getId());
+        } catch (Exception e) {
+            log.error("Ошибка при подготовке события Outbox ({}): {}", action, e.getMessage());
+        }
+    }
+
     @Transactional
     public TransactionDto createTransaction(Long userId, CreateTransactionRequest request) {
         Transaction t = mapper.toEntity(request, userId);
@@ -60,36 +79,10 @@ public class TransactionService {
             sendTransactionEvent(saved);
         }
 
-        log.info("Попытка сохранить событие TRANSACTION_CREATED в Outbox для транзакции {}", saved.getId());
-
-        AuditEventDto createEvent = AuditEventDto.builder()
-                .eventId(UUID.randomUUID().toString())
-                .action("TRANSACTION_CREATED")
-                .userId(userId)
-                .transactionId(saved.getId())
-                .newCategoryId(saved.getCategoryId())
-                .timestamp(LocalDateTime.now())
-                .build();
-
-        try {
-            OutboxEvent outboxEvent = OutboxEvent.builder()
-                    .id(createEvent.getEventId())
-                    .aggregateId(saved.getId().toString())
-                    .eventType("AuditEvent")
-                    .payload(objectMapper.writeValueAsString(createEvent))
-                    .status("PENDING")
-                    .createdAt(LocalDateTime.now())
-                    .build();
-
-            outboxEventRepository.save(outboxEvent);
-            log.info("Событие TRANSACTION_CREATED успешно сохранено в таблицу outbox!");
-        } catch (Exception e) {
-            log.error("КРИТИЧЕСКАЯ ОШИБКА сохранения в Outbox: {}", e.getMessage());
-        }
+        saveAuditToOutbox(saved, "TRANSACTION_CREATED", null);
 
         return mapper.toDto(saved);
     }
-
 
     @Async
     @Transactional
@@ -115,33 +108,72 @@ public class TransactionService {
                 sendTransactionEvent(saved);
             }
 
-            AuditEventDto importEvent = AuditEventDto.builder()
-                    .eventId(UUID.randomUUID().toString())
-                    .action("TRANSACTION_IMPORTED")
-                    .userId(userId)
-                    .transactionId(saved.getId())
-                    .newCategoryId(saved.getCategoryId())
-                    .timestamp(LocalDateTime.now())
-                    .build();
-
-            try {
-                OutboxEvent outboxEvent = OutboxEvent.builder()
-                        .id(importEvent.getEventId())
-                        .aggregateId(saved.getId().toString())
-                        .eventType("TRANSACTION_IMPORTED")
-                        .payload(objectMapper.writeValueAsString(importEvent))
-                        .status("PENDING")
-                        .createdAt(LocalDateTime.now())
-                        .build();
-                outboxEventRepository.save(outboxEvent);
-            } catch (Exception e) {
-                log.error("Ошибка сериализации события аудита (импорт)", e);
-            }
+            saveAuditToOutbox(saved, "TRANSACTION_IMPORTED", null);
 
             newCount++;
         }
 
         return CompletableFuture.completedFuture(newCount);
+    }
+
+    @Transactional
+    public TransactionDto splitTransaction(Long userId, Long transactionId, SplitTransactionRequest request) {
+        Transaction transaction = getByIdAndUser(transactionId, userId);
+        Long oldCategoryId = transaction.getCategoryId();
+
+        BigDecimal totalSplitAmount = request.getSplits().stream()
+                .map(SplitTransactionRequest.SplitPartRequest::getAmount)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+
+        if (totalSplitAmount.compareTo(transaction.getAmount().abs()) != 0) {
+            throw new IllegalArgumentException("Сумма частей не совпадает с суммой транзакции");
+        }
+
+        List<TransactionSplit> existingSplits = splitRepository.findByTransactionId(transactionId);
+        splitRepository.deleteAll(existingSplits);
+
+        List<TransactionSplit> newSplits = request.getSplits().stream()
+                .map(req -> TransactionSplit.builder()
+                        .transaction(transaction)
+                        .categoryId(req.getCategoryId())
+                        .amount(req.getAmount())
+                        .description(req.getDescription())
+                        .build())
+                .toList();
+        splitRepository.saveAll(newSplits);
+
+        transaction.setCategoryId(SPLIT_CATEGORY_ID);
+        repository.save(transaction);
+
+        saveAuditToOutbox(transaction, "TRANSACTION_SPLIT", oldCategoryId);
+
+        return mapper.toDto(transaction);
+    }
+
+    @Transactional
+    public TransactionDto updateTransactionCategory(Long userId, Long id, Long categoryId) {
+        Transaction t = getByIdAndUser(id, userId);
+        Long oldCategoryId = t.getCategoryId();
+
+        if (t.getCategoryId().equals(SPLIT_CATEGORY_ID)) {
+            List<TransactionSplit> existingSplits = splitRepository.findByTransactionId(id);
+            splitRepository.deleteAll(existingSplits);
+        }
+
+        try {
+            categoryQueryService.getCategoryById(categoryId);
+        } catch (EntityNotFoundException e) {
+            throw new IllegalArgumentException("Категория не найдена.");
+        }
+
+        if (!categoryId.equals(oldCategoryId)) {
+            t.setCategoryId(categoryId);
+            t = repository.save(t);
+
+            saveAuditToOutbox(t, "CATEGORY_CHANGED", oldCategoryId);
+        }
+
+        return mapper.toDto(t);
     }
 
     private void sendTransactionEvent(Transaction transaction) {
@@ -178,62 +210,6 @@ public class TransactionService {
         return mapper.toDto(getByIdAndUser(id, userId));
     }
 
-    @Transactional
-    public TransactionDto splitTransaction(Long userId, Long transactionId, SplitTransactionRequest request) {
-        Transaction transaction = getByIdAndUser(transactionId, userId);
-        Long oldCategoryId = transaction.getCategoryId();
-
-        BigDecimal totalSplitAmount = request.getSplits().stream()
-                .map(SplitTransactionRequest.SplitPartRequest::getAmount)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-
-        if (totalSplitAmount.compareTo(transaction.getAmount().abs()) != 0) {
-            throw new IllegalArgumentException("Сумма частей не совпадает с суммой транзакции");
-        }
-
-        List<TransactionSplit> existingSplits = splitRepository.findByTransactionId(transactionId);
-        splitRepository.deleteAll(existingSplits);
-
-        List<TransactionSplit> newSplits = request.getSplits().stream()
-                .map(req -> TransactionSplit.builder()
-                        .transaction(transaction)
-                        .categoryId(req.getCategoryId())
-                        .amount(req.getAmount())
-                        .description(req.getDescription())
-                        .build())
-                .toList();
-        splitRepository.saveAll(newSplits);
-
-        transaction.setCategoryId(SPLIT_CATEGORY_ID);
-        repository.save(transaction);
-
-        AuditEventDto splitEvent = AuditEventDto.builder()
-                .eventId(UUID.randomUUID().toString())
-                .action("TRANSACTION_SPLIT")
-                .userId(userId)
-                .transactionId(transactionId)
-                .oldCategoryId(oldCategoryId)
-                .newCategoryId(SPLIT_CATEGORY_ID)
-                .timestamp(LocalDateTime.now())
-                .build();
-
-        try {
-            OutboxEvent outboxEvent = OutboxEvent.builder()
-                    .id(splitEvent.getEventId())
-                    .aggregateId(transactionId.toString())
-                    .eventType("TRANSACTION_SPLIT")
-                    .payload(objectMapper.writeValueAsString(splitEvent))
-                    .status("PENDING")
-                    .createdAt(LocalDateTime.now())
-                    .build();
-            outboxEventRepository.save(outboxEvent);
-        } catch (Exception e) {
-            log.error("Ошибка сериализации события аудита (сплит)", e);
-        }
-
-        return mapper.toDto(transaction);
-    }
-
     private Transaction convertBankDtoToTransaction(Long userId, TransactionDto bankDto) {
         BigDecimal absAmount = bankDto.getAmount().abs().setScale(2, RoundingMode.HALF_UP);
         OperationType type = bankDto.getAmount().signum() >= 0 ? OperationType.INCOME : OperationType.EXPENSE;
@@ -257,55 +233,6 @@ public class TransactionService {
             }
         }
         return UNCATEGORIZED_ID;
-    }
-
-    @Transactional
-    public TransactionDto updateTransactionCategory(Long userId, Long id, Long categoryId) {
-        Transaction t = getByIdAndUser(id, userId);
-        Long oldCategoryId = t.getCategoryId();
-
-        if (t.getCategoryId().equals(SPLIT_CATEGORY_ID)) {
-            List<TransactionSplit> existingSplits = splitRepository.findByTransactionId(id);
-            splitRepository.deleteAll(existingSplits);
-        }
-
-        try {
-            categoryQueryService.getCategoryById(categoryId);
-        } catch (EntityNotFoundException e) {
-            throw new IllegalArgumentException("Категория не найдена.");
-        }
-
-        if (!categoryId.equals(oldCategoryId)) {
-            t.setCategoryId(categoryId);
-            t = repository.save(t);
-
-            AuditEventDto eventDto = AuditEventDto.builder()
-                    .eventId(UUID.randomUUID().toString())
-                    .action("CATEGORY_CHANGED")
-                    .userId(userId)
-                    .transactionId(id)
-                    .oldCategoryId(oldCategoryId)
-                    .newCategoryId(categoryId)
-                    .timestamp(LocalDateTime.now())
-                    .build();
-
-            try {
-                OutboxEvent outboxEvent = OutboxEvent.builder()
-                        .id(eventDto.getEventId())
-                        .aggregateId(String.valueOf(id))
-                        .eventType("CATEGORY_CHANGED")
-                        .payload(objectMapper.writeValueAsString(eventDto))
-                        .status("PENDING")
-                        .createdAt(LocalDateTime.now())
-                        .build();
-                outboxEventRepository.save(outboxEvent);
-            } catch (Exception e) {
-                log.error("Ошибка при сериализации события аудита", e);
-                throw new RuntimeException("Ошибка при сохранении события аудита", e);
-            }
-        }
-
-        return mapper.toDto(t);
     }
 
     private Transaction getByIdAndUser(Long id, Long userId) {

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -56,6 +56,7 @@ public class TransactionService {
             AuditEventDto eventDto = mapper.toAuditEventDto(transaction, action, oldCategoryId);
 
             OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .id(java.util.UUID.randomUUID().toString())
                     .aggregateId(transaction.getId().toString())
                     .eventType(action)
                     .payload(objectMapper.writeValueAsString(eventDto))
@@ -102,11 +103,13 @@ public class TransactionService {
                     .toList();
 
             for (TransactionDto bankDto : bankTransactions) {
-                if (repository.findByUserIdAndBankTransactionRefId(userId, bankDto.getExternalId()).isPresent()) {
+                String uniqueRefId = bankDto.getExternalId() + "-u" + userId;
+
+                if (repository.findByUserIdAndBankTransactionRefId(userId, uniqueRefId).isPresent()) {
                     continue;
                 }
 
-                Transaction transaction = convertBankDtoToTransaction(userId, bankDto);
+                Transaction transaction = convertBankDtoToTransaction(userId, bankDto, uniqueRefId);
                 Long categoryId = autoClassify(transaction, sortedStrategies);
                 transaction.setCategoryId(categoryId);
 
@@ -227,7 +230,7 @@ public class TransactionService {
         return mapper.toDto(getByIdAndUser(id, userId));
     }
 
-    private Transaction convertBankDtoToTransaction(Long userId, TransactionDto bankDto) {
+    private Transaction convertBankDtoToTransaction(Long userId, TransactionDto bankDto, String uniqueRefId) {
         BigDecimal absAmount = bankDto.getAmount().abs().setScale(2, RoundingMode.HALF_UP);
         OperationType type = bankDto.getAmount().signum() >= 0 ? OperationType.INCOME : OperationType.EXPENSE;
         return Transaction.builder()
@@ -238,7 +241,7 @@ public class TransactionService {
                 .mcc(bankDto.getMcc())
                 .merchant(bankDto.getMerchantName())
                 .description(bankDto.getDescription())
-                .bankTransactionRefId(bankDto.getExternalId())
+                .bankTransactionRefId(uniqueRefId)
                 .build();
     }
 

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -56,10 +56,15 @@ public class TransactionService {
             AuditEventDto eventDto = mapper.toAuditEventDto(transaction, action, oldCategoryId);
 
             OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .aggregateId(transaction.getId().toString())
+                    .eventType(action)
                     .payload(objectMapper.writeValueAsString(eventDto))
+                    .status("PENDING")
+                    .createdAt(LocalDateTime.now())
                     .build();
 
             outboxEventRepository.save(outboxEvent);
+            log.info("Событие {} успешно сохранено в Outbox для транзакции {}", action, transaction.getId());
         } catch (Exception e) {
             log.error("Ошибка при подготовке события Outbox ({}): {}", action, e.getMessage());
         }

--- a/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
+++ b/transaction-service/src/main/java/com/teamfourpixels/service/TransactionService.java
@@ -1,10 +1,13 @@
 package com.teamfourpixels.service;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.teamfourpixels.dto.*;
+import com.teamfourpixels.entity.OutboxEvent;
 import com.teamfourpixels.entity.Transaction;
 import com.teamfourpixels.entity.TransactionSplit;
 import com.teamfourpixels.enums.OperationType;
 import com.teamfourpixels.mapper.TransactionMapper;
+import com.teamfourpixels.repository.OutboxEventRepository;
 import com.teamfourpixels.repository.TransactionRepository;
 import com.teamfourpixels.repository.TransactionSplitRepository;
 import com.teamfourpixels.service.classification.ClassificationStrategy;
@@ -26,6 +29,7 @@ import java.time.ZoneId;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 
 @Slf4j
@@ -41,6 +45,9 @@ public class TransactionService {
 
     private final KafkaTemplate<String, TransactionCreatedEvent> kafkaTemplate;
 
+    private final OutboxEventRepository outboxEventRepository;
+    private final ObjectMapper objectMapper;
+
     private static final Long UNCATEGORIZED_ID = 999L;
     private static final Long SPLIT_CATEGORY_ID = -1L;
 
@@ -53,8 +60,36 @@ public class TransactionService {
             sendTransactionEvent(saved);
         }
 
+        log.info("Попытка сохранить событие TRANSACTION_CREATED в Outbox для транзакции {}", saved.getId());
+
+        AuditEventDto createEvent = AuditEventDto.builder()
+                .eventId(UUID.randomUUID().toString())
+                .action("TRANSACTION_CREATED")
+                .userId(userId)
+                .transactionId(saved.getId())
+                .newCategoryId(saved.getCategoryId())
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        try {
+            OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .id(createEvent.getEventId())
+                    .aggregateId(saved.getId().toString())
+                    .eventType("AuditEvent")
+                    .payload(objectMapper.writeValueAsString(createEvent))
+                    .status("PENDING")
+                    .createdAt(LocalDateTime.now())
+                    .build();
+
+            outboxEventRepository.save(outboxEvent);
+            log.info("Событие TRANSACTION_CREATED успешно сохранено в таблицу outbox!");
+        } catch (Exception e) {
+            log.error("КРИТИЧЕСКАЯ ОШИБКА сохранения в Outbox: {}", e.getMessage());
+        }
+
         return mapper.toDto(saved);
     }
+
 
     @Async
     @Transactional
@@ -78,6 +113,29 @@ public class TransactionService {
 
             if (saved.getType() == OperationType.EXPENSE) {
                 sendTransactionEvent(saved);
+            }
+
+            AuditEventDto importEvent = AuditEventDto.builder()
+                    .eventId(UUID.randomUUID().toString())
+                    .action("TRANSACTION_IMPORTED")
+                    .userId(userId)
+                    .transactionId(saved.getId())
+                    .newCategoryId(saved.getCategoryId())
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            try {
+                OutboxEvent outboxEvent = OutboxEvent.builder()
+                        .id(importEvent.getEventId())
+                        .aggregateId(saved.getId().toString())
+                        .eventType("TRANSACTION_IMPORTED")
+                        .payload(objectMapper.writeValueAsString(importEvent))
+                        .status("PENDING")
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                outboxEventRepository.save(outboxEvent);
+            } catch (Exception e) {
+                log.error("Ошибка сериализации события аудита (импорт)", e);
             }
 
             newCount++;
@@ -123,6 +181,7 @@ public class TransactionService {
     @Transactional
     public TransactionDto splitTransaction(Long userId, Long transactionId, SplitTransactionRequest request) {
         Transaction transaction = getByIdAndUser(transactionId, userId);
+        Long oldCategoryId = transaction.getCategoryId();
 
         BigDecimal totalSplitAmount = request.getSplits().stream()
                 .map(SplitTransactionRequest.SplitPartRequest::getAmount)
@@ -147,6 +206,30 @@ public class TransactionService {
 
         transaction.setCategoryId(SPLIT_CATEGORY_ID);
         repository.save(transaction);
+
+        AuditEventDto splitEvent = AuditEventDto.builder()
+                .eventId(UUID.randomUUID().toString())
+                .action("TRANSACTION_SPLIT")
+                .userId(userId)
+                .transactionId(transactionId)
+                .oldCategoryId(oldCategoryId)
+                .newCategoryId(SPLIT_CATEGORY_ID)
+                .timestamp(LocalDateTime.now())
+                .build();
+
+        try {
+            OutboxEvent outboxEvent = OutboxEvent.builder()
+                    .id(splitEvent.getEventId())
+                    .aggregateId(transactionId.toString())
+                    .eventType("TRANSACTION_SPLIT")
+                    .payload(objectMapper.writeValueAsString(splitEvent))
+                    .status("PENDING")
+                    .createdAt(LocalDateTime.now())
+                    .build();
+            outboxEventRepository.save(outboxEvent);
+        } catch (Exception e) {
+            log.error("Ошибка сериализации события аудита (сплит)", e);
+        }
 
         return mapper.toDto(transaction);
     }
@@ -179,6 +262,7 @@ public class TransactionService {
     @Transactional
     public TransactionDto updateTransactionCategory(Long userId, Long id, Long categoryId) {
         Transaction t = getByIdAndUser(id, userId);
+        Long oldCategoryId = t.getCategoryId();
 
         if (t.getCategoryId().equals(SPLIT_CATEGORY_ID)) {
             List<TransactionSplit> existingSplits = splitRepository.findByTransactionId(id);
@@ -191,8 +275,37 @@ public class TransactionService {
             throw new IllegalArgumentException("Категория не найдена.");
         }
 
-        t.setCategoryId(categoryId);
-        return mapper.toDto(repository.save(t));
+        if (!categoryId.equals(oldCategoryId)) {
+            t.setCategoryId(categoryId);
+            t = repository.save(t);
+
+            AuditEventDto eventDto = AuditEventDto.builder()
+                    .eventId(UUID.randomUUID().toString())
+                    .action("CATEGORY_CHANGED")
+                    .userId(userId)
+                    .transactionId(id)
+                    .oldCategoryId(oldCategoryId)
+                    .newCategoryId(categoryId)
+                    .timestamp(LocalDateTime.now())
+                    .build();
+
+            try {
+                OutboxEvent outboxEvent = OutboxEvent.builder()
+                        .id(eventDto.getEventId())
+                        .aggregateId(String.valueOf(id))
+                        .eventType("CATEGORY_CHANGED")
+                        .payload(objectMapper.writeValueAsString(eventDto))
+                        .status("PENDING")
+                        .createdAt(LocalDateTime.now())
+                        .build();
+                outboxEventRepository.save(outboxEvent);
+            } catch (Exception e) {
+                log.error("Ошибка при сериализации события аудита", e);
+                throw new RuntimeException("Ошибка при сохранении события аудита", e);
+            }
+        }
+
+        return mapper.toDto(t);
     }
 
     private Transaction getByIdAndUser(Long id, Long userId) {

--- a/transaction-service/src/main/resources/db/changelog/changes/04-create-outbox-table.sql
+++ b/transaction-service/src/main/resources/db/changelog/changes/04-create-outbox-table.sql
@@ -1,0 +1,10 @@
+CREATE TABLE outbox_events (
+    id VARCHAR(36) PRIMARY KEY,
+    aggregate_id VARCHAR(255) NOT NULL,
+    event_type VARCHAR(255) NOT NULL,
+    payload TEXT NOT NULL,
+    status VARCHAR(50) NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE INDEX idx_outbox_status ON outbox_events(status);

--- a/transaction-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/transaction-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -5,3 +5,5 @@ databaseChangeLog:
       file: db/changelog/changes/02-create-categorization-rules-table.sql
   - include:
       file: db/changelog/changes/03-create-transaction-splits-table.sql
+  - include:
+      file: db/changelog/changes/04-create-outbox-table.sql


### PR DESCRIPTION
система построена на событийно-ориентированной архитектуре с использованием  кафки

### Применяются два способа отправки в аудит:

- **Прямая отправка:** используется в `budget-service` для мгновенных уведомлений и логов настроек
    
- **Transactional Outbox:** используется в `transaction-service`. События сначала сохраняются в таблицу `outbox_events` в одной транзакции с бизнес-данными, а затем отдельный планировщик (`OutboxScheduler`) пересылает их в кафку. Это гарантирует, что лог в аудите появится только если транзакция в основной базе прошла успешно
    
### Фиксируем следующие события:

**Микросервис транзакций:**

- `TRANSACTION_CREATED` — создание новой расходной или доходной операции
    
- `TRANSACTION_IMPORTED` — автоматический импорт данных из банковских выписок
    
- `TRANSACTION_SPLIT` — разделение одной транзакции на несколько категорий 

- `CATEGORY_CHANGED` — изменение категории у существующей транзакции 
    

**Микросервис бюджета:**

- `BUDGET_CONFIGURED` — создание или изменение общего плана бюджета на месяц
    
- `BUDGET_DELETED` — удаление бюджетного плана
    
- `LIMIT_REACHED_80` / `LIMIT_REACHED_100` — автоматические уведомления о достижении 80% или 100% лимита по конкретной категории
    

### Структура хранимых данных

Каждая запись в базе данных аудита содержит:

- **Уникальный ID события** 
    
- **Тип действия:** например `LIMIT_REACHED_100`)
    
- **Данные о пользователе:** `userId`
    
- **Связь с объектом:** `transactionId`
    
- **Детали изменений:** `oldCategoryId` и `newCategoryId`
    
- **Временные метки:** `timestamp`  и `processedAt` 
    

### API Доступа

Реализован эндпоинт `GET /api/v1/audit/user`, который возвращает полный список событий для текущего пользователя, он отсортирован от новых к старым